### PR TITLE
Stop using `process.umask()`

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Run tests
         run: npm test
+        env:
+          VERBOSE: true
 
       - name: Coveralls
         uses: coverallsapp/github-action@v1.1.0

--- a/mkdirp.js
+++ b/mkdirp.js
@@ -5,21 +5,20 @@ var path = require('path');
 var fs = require('graceful-fs');
 
 var MASK_MODE = parseInt('7777', 8);
-var DEFAULT_DIR_MODE = parseInt('0777', 8);
 
-function mkdirp(dirpath, customMode, callback) {
-  if (typeof customMode === 'function') {
-    callback = customMode;
-    customMode = undefined;
+function mkdirp(dirpath, mode, callback) {
+  if (typeof mode === 'function') {
+    callback = mode;
+    mode = undefined;
   }
 
-  var mode = customMode || DEFAULT_DIR_MODE;
   if (typeof mode === 'string') {
     mode = parseInt(mode, 8);
   }
+
   dirpath = path.resolve(dirpath);
 
-  fs.mkdir(dirpath, mode, onMkdir);
+  fs.mkdir(dirpath, { mode: mode }, onMkdir);
 
   function onMkdir(mkdirErr) {
     if (!mkdirErr) {
@@ -49,7 +48,7 @@ function mkdirp(dirpath, customMode, callback) {
         return callback(mkdirErr);
       }
 
-      if (!customMode) {
+      if (!mode) {
         return callback();
       }
 
@@ -66,7 +65,7 @@ function mkdirp(dirpath, customMode, callback) {
       return callback(recurseErr);
     }
 
-    mkdirp(dirpath, customMode, callback);
+    mkdirp(dirpath, mode, callback);
   }
 }
 

--- a/mkdirp.js
+++ b/mkdirp.js
@@ -14,6 +14,9 @@ function mkdirp(dirpath, customMode, callback) {
   }
 
   var mode = customMode || DEFAULT_DIR_MODE;
+  if (typeof mode === 'string') {
+    mode = parseInt(mode, 8);
+  }
   dirpath = path.resolve(dirpath);
 
   fs.mkdir(dirpath, mode, onMkdir);
@@ -50,7 +53,6 @@ function mkdirp(dirpath, customMode, callback) {
         return callback();
       }
 
-      // TODO: Is it proper to mask like this?
       if ((stats.mode & MASK_MODE) === mode) {
         return callback();
       }

--- a/mkdirp.js
+++ b/mkdirp.js
@@ -18,7 +18,7 @@ function mkdirp(dirpath, mode, callback) {
 
   dirpath = path.resolve(dirpath);
 
-  fs.mkdir(dirpath, { mode: mode }, onMkdir);
+  fs.mkdir(dirpath, mode, onMkdir);
 
   function onMkdir(mkdirErr) {
     if (!mkdirErr) {

--- a/mkdirp.js
+++ b/mkdirp.js
@@ -13,7 +13,7 @@ function mkdirp(dirpath, customMode, callback) {
     customMode = undefined;
   }
 
-  var mode = customMode || DEFAULT_DIR_MODE & ~process.umask();
+  var mode = customMode || DEFAULT_DIR_MODE;
   dirpath = path.resolve(dirpath);
 
   fs.mkdir(dirpath, mode, onMkdir);
@@ -46,12 +46,12 @@ function mkdirp(dirpath, customMode, callback) {
         return callback(mkdirErr);
       }
 
-      // TODO: Is it proper to mask like this?
-      if ((stats.mode & MASK_MODE) === mode) {
+      if (!customMode) {
         return callback();
       }
 
-      if (!customMode) {
+      // TODO: Is it proper to mask like this?
+      if ((stats.mode & MASK_MODE) === mode) {
         return callback();
       }
 
@@ -64,7 +64,7 @@ function mkdirp(dirpath, customMode, callback) {
       return callback(recurseErr);
     }
 
-    mkdirp(dirpath, mode, callback);
+    mkdirp(dirpath, customMode, callback);
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,12 @@ describe('mkdirpStream', function () {
       mode = parseInt(mode, 8);
     }
 
-    return mode & ~process.umask();
+    // Set to use to "get" it
+    var current = process.umask(0);
+    // Then set it back for the next test
+    process.umask(current);
+
+    return mode & ~current;
   }
 
   beforeEach(cleanup);

--- a/test/mkdirp.js
+++ b/test/mkdirp.js
@@ -43,7 +43,12 @@ describe('mkdirp', function () {
       mode = parseInt(mode, 8);
     }
 
-    return mode & ~process.umask();
+    // Set to use to "get" it
+    var current = process.umask(0);
+    // Then set it back for the next test
+    process.umask(current);
+
+    return mode & ~current;
   }
 
   beforeEach(cleanup);

--- a/test/mkdirp.js
+++ b/test/mkdirp.js
@@ -58,14 +58,19 @@ function suite () {
       mode = parseInt(mode, 8);
     }
 
+    log.expected(mode);
+    return mode;
+  }
+
+  function expectedDefaultMode()  {
     // Set to use to "get" it
     var current = process.umask(0);
     // Then set it back for the next test
     process.umask(current);
 
-    var umaskedMode = (mode & ~current);
-    log.expected(umaskedMode);
-    return umaskedMode;
+    var mode = (DEFAULT_DIR_MODE & ~current);
+    log.expected(mode);
+    return mode;
   }
 
   beforeEach(cleanup);
@@ -100,7 +105,7 @@ function suite () {
 
     mkdirp(outputDirpath, function (err) {
       expect(err).toBeFalsy();
-      expect(createdMode(outputDirpath)).toEqual(expectedMode(DEFAULT_DIR_MODE));
+      expect(createdMode(outputDirpath)).toEqual(expectedDefaultMode());
 
       done();
     });
@@ -123,7 +128,7 @@ function suite () {
 
     mkdirp(outputNestedDirpath, function (err) {
       expect(err).toBeFalsy();
-      expect(createdMode(outputNestedDirpath)).toEqual(expectedMode(DEFAULT_DIR_MODE));
+      expect(createdMode(outputNestedDirpath)).toEqual(expectedDefaultMode());
 
       done();
     });
@@ -135,7 +140,7 @@ function suite () {
       return;
     }
 
-    var mode = '700';
+    var mode = '777';
 
     mkdirp(outputDirpath, mode, function (err) {
       expect(err).toBeFalsy();
@@ -151,7 +156,7 @@ function suite () {
       return;
     }
 
-    var mode = parseInt('700', 8);
+    var mode = parseInt('777', 8);
 
     mkdirp(outputDirpath, mode, function (err) {
       expect(err).toBeFalsy();
@@ -159,7 +164,23 @@ function suite () {
 
       done();
     });
-  })
+  });
+
+  it('does not mask a custom mode', function (done) {
+    if (isWindows) {
+      this.skip();
+      return;
+    }
+
+    var mode = parseInt('777', 8);
+
+    mkdirp(outputDirpath, mode, function (err) {
+      expect(err).toBeFalsy();
+      expect(createdMode(outputDirpath)).toEqual(mode);
+
+      done();
+    });
+  });
 
   it('can create a directory with setgid permission', function (done) {
     if (isWindows) {
@@ -183,7 +204,7 @@ function suite () {
       return;
     }
 
-    var mode = '700';
+    var mode = '777';
 
     mkdirp(outputDirpath, mode, function (err) {
       expect(err).toBeFalsy();
@@ -203,7 +224,7 @@ function suite () {
       return;
     }
 
-    var mode = '700';
+    var mode = '777';
 
     mkdirp(outputNestedDirpath, mode, function (err) {
       expect(err).toBeFalsy();
@@ -220,12 +241,12 @@ function suite () {
     }
 
     var intermediateDirpath = path.dirname(outputNestedDirpath);
-    var mode = '700';
+    var mode = '777';
 
     mkdirp(outputNestedDirpath, mode, function (err) {
       expect(err).toBeFalsy();
-      expect(createdMode(outputDirpath)).toEqual(expectedMode(DEFAULT_DIR_MODE));
-      expect(createdMode(intermediateDirpath)).toEqual(expectedMode(DEFAULT_DIR_MODE));
+      expect(createdMode(outputDirpath)).toEqual(expectedDefaultMode());
+      expect(createdMode(intermediateDirpath)).toEqual(expectedDefaultMode());
       expect(createdMode(outputNestedDirpath)).toEqual(expectedMode(mode));
 
       done();
@@ -238,11 +259,11 @@ function suite () {
       return;
     }
 
-    var mode = '700';
+    var mode = '777';
 
     mkdirp(outputDirpath, function (err) {
       expect(err).toBeFalsy();
-      expect(createdMode(outputDirpath)).toEqual(expectedMode(DEFAULT_DIR_MODE));
+      expect(createdMode(outputDirpath)).toEqual(expectedDefaultMode());
 
       mkdirp(outputDirpath, mode, function (err2) {
         expect(err2).toBeFalsy();
@@ -276,7 +297,7 @@ function suite () {
       return;
     }
 
-    var mode = '700';
+    var mode = '777';
 
     mkdirp(outputDirpath, function (err) {
       expect(err).toBeFalsy();
@@ -334,7 +355,7 @@ function suite () {
       return;
     }
 
-    var mode = '700';
+    var mode = '777';
 
     mkdirp(outputDirpath, mode, function (err) {
       expect(err).toBeFalsy();
@@ -370,4 +391,4 @@ describe('mkdirp with umask', function() {
 
   // Initialize the normal suite
   suite();
-})
+});

--- a/test/mkdirp.js
+++ b/test/mkdirp.js
@@ -10,8 +10,6 @@ var rimraf = require('rimraf');
 
 var mkdirp = require('../mkdirp');
 
-// process.umask(parseInt('002', 8))
-
 var log = {
   expected: function(expected) {
     if (process.env.VERBOSE) {
@@ -25,7 +23,7 @@ var log = {
   }
 }
 
-describe('mkdirp', function () {
+function suite () {
   var MASK_MODE = parseInt('7777', 8);
   var DEFAULT_DIR_MODE = parseInt('0777', 8);
   var isWindows = os.platform() === 'win32';
@@ -351,4 +349,25 @@ describe('mkdirp', function () {
       });
     });
   });
-});
+}
+
+describe('mkdirp', suite);
+
+describe('mkdirp with umask', function() {
+
+  var startingUmask;
+  before(function(done) {
+    startingUmask = process.umask(parseInt('066', 8));
+
+    done();
+  });
+
+  after(function(done) {
+    process.umask(startingUmask);
+
+    done();
+  })
+
+  // Initialize the normal suite
+  suite();
+})


### PR DESCRIPTION
Ref nodejs/node#32321

---

This can result in a behavior change in an edge case:
* We attempt to create `./dir` without providing `customMode`.
* `./dir` already exists but has a difference mode than the current `process.umask()`.

I think the current release would reset the existing directory to match the current umask where the new code will leave it alone.