### PR TITLE
Breaking: Switch to streamx, drop `.obj` function

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-test/fixtures/
-coverage/
-.nyc_output/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var mkdirpStream = require('fs-mkdirp-stream');
 from
   .obj([{ dirname: '/path/to/my/', path: '/path/to/my/file.js' }])
   .pipe(
-    mkdirpStream.obj(function (obj, callback) {
+    mkdirpStream(function (obj, callback) {
       // callback can take 3 arguments (err, dirname, mode)
       callback(null, obj.dirname);
     })
@@ -37,15 +37,11 @@ from
 
 ### `mkdirpStream(resolver)`
 
-Takes a `resolver` function or string and returns a `through2` stream.
+Takes a `resolver` function or string and returns a `streamx.Transform` stream.
 
 If the `resolver` is a function, it will be called once per chunk with the signature `(chunk, callback)`. The `callback(error, dirpath, mode)` must be called with the `dirpath` to be created as the 2nd parameter or an `error` as the 1st parameter; optionally with a `mode` as the 3rd parameter.
 
 If the `resolver` is a string, it will be created/ensured for each chunk (e.g. if it were deleted between chunks, it would be recreated). When using a string, a custom `mode` can't be used.
-
-### `mkdirpStream.obj(resolver)`
-
-The same as the top-level API but for object streams. See the example to see the benefit of object streams with this module.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { Transform } = require('streamx');
+var Transform = require('streamx').Transform;
 
-const mkdirp = require('./mkdirp');
+var mkdirp = require('./mkdirp');
 
 function toFunction(dirpath) {
   function stringResolver(chunk, callback) {
@@ -19,7 +19,7 @@ function mkdirpStream(resolver) {
   }
 
   return new Transform({
-    transform(chunk, callback) {
+    transform: function (chunk, callback) {
       resolver(chunk, onDirpath);
 
       function onDirpath(dirpathErr, dirpath, mode) {

--- a/package.json
+++ b/package.json
@@ -24,14 +24,13 @@
   },
   "dependencies": {
     "graceful-fs": "^4.1.11",
-    "through2": "^2.0.3"
+    "streamx": "^2.6.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
-    "eslint-config-gulp": "^4.0.0",
+    "eslint-config-gulp": "coreyfarrell/eslint-config-gulp#support-node10",
     "expect": "^25.4.0",
     "jest-mock": "^25.5.0",
-    "mississippi": "^1.3.0",
     "mocha": "^7.1.2",
     "nyc": "^15.0.1",
     "rimraf": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-config-gulp": "coreyfarrell/eslint-config-gulp#support-node10",
-    "expect": "^25.4.0",
-    "jest-mock": "^25.5.0",
+    "expect": "^26.0.1",
+    "jest-mock": "^26.0.1",
     "mocha": "^7.1.2",
     "nyc": "^15.0.1",
-    "rimraf": "^2.6.1"
+    "rimraf": "^3.0.2"
   },
   "nyc": {
     "reporter": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "eslint": "^6.8.0",
-    "eslint-config-gulp": "coreyfarrell/eslint-config-gulp#support-node10",
+    "eslint-config-gulp": "^5.0.0",
     "expect": "^26.0.1",
     "jest-mock": "^26.0.1",
     "mocha": "^7.1.2",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "gulp/test"
-}

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,9 @@ var fs = require('graceful-fs');
 var mock = require('jest-mock');
 var expect = require('expect');
 var rimraf = require('rimraf');
-var Readable = require('streamx').Readable;
+var streamx = require('streamx');
+var Readable = streamx.Readable;
+var Writable = streamx.Writable;
 
 var mkdirpStream = require('../');
 
@@ -75,7 +77,7 @@ describe('mkdirpStream', function () {
       done(err);
     }
 
-    pipeline(Readable.from(['test']), mkdirpStream(outputDirpath), assert);
+    pipeline(Readable.from(['test']), mkdirpStream(outputDirpath), new Writable(), assert);
   });
 
   it('takes a resolver function that receives chunk', function (done) {
@@ -91,7 +93,7 @@ describe('mkdirpStream', function () {
       done(err);
     }
 
-    pipeline(Readable.from(['test']), mkdirpStream(resolver), assert);
+    pipeline(Readable.from(['test']), mkdirpStream(resolver), new Writable(), assert);
   });
 
   it('can pass a mode as the 3rd argument to the resolver callback', function (done) {
@@ -114,7 +116,7 @@ describe('mkdirpStream', function () {
       done(err);
     }
 
-    pipeline(Readable.from(['test']), mkdirpStream(resolver), assert);
+    pipeline(Readable.from(['test']), mkdirpStream(resolver), new Writable(), assert);
   });
 
   it('can pass an error as the 1st argument to the resolver callback to error', function (done) {
@@ -132,7 +134,7 @@ describe('mkdirpStream', function () {
       done();
     }
 
-    pipeline(Readable.from(['test']), mkdirpStream(resolver), assert);
+    pipeline(Readable.from(['test']), mkdirpStream(resolver), new Writable(), assert);
   });
 
   it('works with objectMode', function (done) {
@@ -150,6 +152,7 @@ describe('mkdirpStream', function () {
     pipeline(
       Readable.from([{ dirname: outputDirpath }]),
       mkdirpStream(resolver),
+      new Writable(),
       assert
     );
   });
@@ -169,6 +172,6 @@ describe('mkdirpStream', function () {
       done();
     }
 
-    pipeline(Readable.from(['test']), mkdirpStream(outputDirpath), assert);
+    pipeline(Readable.from(['test']), mkdirpStream(outputDirpath), new Writable(), assert);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,13 @@
 
 var os = require('os');
 var path = require('path');
-var {pipeline} = require('stream');
+var pipeline = require('stream').pipeline;
 
 var fs = require('graceful-fs');
 var mock = require('jest-mock');
 var expect = require('expect');
 var rimraf = require('rimraf');
-var {Readable} = require('streamx');
+var Readable = require('streamx').Readable;
 
 var mkdirpStream = require('../');
 


### PR DESCRIPTION
Fixes #7

---

Not ready for merge as eslint-config-gulp is currently installed from a branch on my github fork.